### PR TITLE
Add pretrained state dict loader

### DIFF
--- a/models/metric/model_train_metric.py
+++ b/models/metric/model_train_metric.py
@@ -437,5 +437,19 @@ class Model():
 
         
     def load_pretrained_state_dict(self, state_dict):
-        own_state=self.state_dict
+        """Load a checkpoint dictionary into the current model."""
+
+        # B matrix used by the network
+        self.B = state_dict['B_state_dict'].to(self.Params['Device'])
+
+        # Recreate the network with the loaded B and copy parameters
+        self.network = model_network.NN(self.Params['Device'], self.dim, self.B)
+        self.network.load_state_dict(state_dict['model_state_dict'], strict=True)
+        self.network.to(torch.device(self.Params['Device']))
+        self.network.float()
+        self.network.eval()
+
+        # Recreate helper function object on the correct device
+        self.function = model_function.Function(
+            self.folder, self.Params['Device'], self.network, self.dim)
 

--- a/tests/test_load_pretrained_state_dict.py
+++ b/tests/test_load_pretrained_state_dict.py
@@ -1,0 +1,27 @@
+import pytest
+import torch
+
+from models.metric import model_network_metric as model_network
+from models.metric import model_train_metric as md
+
+
+def create_model():
+    model = md.Model('tmp_model', 'data/tmp/path', dim=3, source=[0,0,0], device='cpu')
+    model.B = torch.randn(128, 3)
+    model.network = model_network.NN(model.Params['Device'], model.dim, model.B)
+    return model
+
+
+def test_load_pretrained_state_dict():
+    m1 = create_model()
+    state = {
+        'model_state_dict': m1.network.state_dict(),
+        'B_state_dict': m1.B.clone(),
+    }
+    m2 = md.Model('tmp_model', 'data/tmp/path', dim=3, source=[0,0,0], device='cpu')
+    m2.load_pretrained_state_dict(state)
+
+    for p1, p2 in zip(m1.network.parameters(), m2.network.parameters()):
+        assert torch.allclose(p1, p2)
+    assert torch.equal(m2.B, m1.B)
+    assert m2.B.device.type == 'cpu'


### PR DESCRIPTION
## Summary
- implement `load_pretrained_state_dict` in training metric model
- add regression test for state dict loading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6843be28c064832c8acde4314c77937b