### PR TITLE
Add CLI entrypoints for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ This is a minimal example.
 3. run `docker run -u $(id -u):$(id -g) --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume="/home/n/Eikonal_Planning/ntrl-demo:/workspace" --volume="/usr/lib/x86_64-linux-gnu/:/glu" --volume="/home/n/.local:/.local" --env="QT_X11_NO_MITSHM=1"  --gpus all -ti --rm ntrl:demo` to start the docker container.
 4. Find `torch_kdtree` and install
 5. run `python dataprocessing/preprocess.py --config configs/gibson.txt ` to sample training data
-6. run `python train/train_gib.py` to start the training. 
+6. run `python train/train_gib.py --data <dataset_dir> --output <experiment_dir>` to train on the Gibson dataset.
+7. run `python train/train_maze.py --data <dataset_dir> --output <experiment_dir>` to train on the Maze dataset.

--- a/train/train_gib.py
+++ b/train/train_gib.py
@@ -1,18 +1,36 @@
 import sys
 sys.path.append('.')
+import argparse
 from models.metric import model_train_metric as md
-from os import path
-from glob import glob
-
-modelPath = './Experiments/Gib'
-#dataPath = './datasets/gibson/Auburn'
-dataPath = './datasets/gibson/Spotswood'
 
 
+def main(args=None):
+    parser = argparse.ArgumentParser(description="Train the Gibson model")
+    parser.add_argument(
+        "--data",
+        default="./datasets/gibson/Spotswood",
+        help="Path to the dataset directory",
+    )
+    parser.add_argument(
+        "--output",
+        default="./Experiments/Gib",
+        help="Directory where the model checkpoints will be saved",
+    )
 
-#model    = md.Model(modelPath, dataPath, 3, [0, 0.3,-0.03],device='cuda:0')
-model    = md.Model(modelPath, dataPath, 3, [-0.15, 0.1,0.1],device='cuda:0')
+    opts = parser.parse_args(args)
 
-model.train()
+    model = md.Model(
+        opts.output,
+        opts.data,
+        3,
+        [-0.15, 0.1, 0.1],
+        device="cuda:0",
+    )
+
+    model.train()
+
+
+if __name__ == "__main__":
+    main()
 
 

--- a/train/train_maze.py
+++ b/train/train_maze.py
@@ -1,26 +1,36 @@
 import sys
 sys.path.append('.')
-from models.metric import model_train_metric as md#_newout_sqrtlog _newout_log2
-#from models import model_train as md
-from os import path
-
-modelPath = './Experiments/Maze'
-
-dataPath = './datasets/test/maze'
+import argparse
+from models.metric import model_train_metric as md  # _newout_sqrtlog _newout_log2
 
 
-# #model    = md.Model(modelPath, dataPath, 2,[-0.0,-0.0], device='cuda:0')
+def main(args=None):
+    parser = argparse.ArgumentParser(description="Train the Maze model")
+    parser.add_argument(
+        "--data",
+        default="./datasets/test/maze",
+        help="Path to the dataset directory",
+    )
+    parser.add_argument(
+        "--output",
+        default="./Experiments/Maze",
+        help="Directory where the model checkpoints will be saved",
+    )
 
-#model    = md.Model(modelPath, dataPath, 2,[-0.45,-0.45], device='cuda:0')
-# #model    = md.Model(modelPath, dataPath, 2,[0.03,-0.45], device='cuda:0')
+    opts = parser.parse_args(args)
 
-#dataPath = './datasets/test/maze5'
+    model = md.Model(
+        opts.output,
+        opts.data,
+        2,
+        [-0.0, -0.0],
+        device="cuda:0",
+    )
 
-model    = md.Model(modelPath, dataPath, 2,[-0.0,-0.0], device='cuda:0')
+    model.train()
 
-#model    = md.Model(modelPath, dataPath, 2,[-0.0,-0.0], device='cuda:0')
-#model    = md.Model(modelPath, dataPath, 2,[0.03,-0.45], device='cuda:0')
 
-model.train()
+if __name__ == "__main__":
+    main()
 
 


### PR DESCRIPTION
## Summary
- add argparse `main()` entrypoints to training scripts
- document new CLI usage in README

## Testing
- `python -m py_compile train/train_gib.py train/train_maze.py`

------
https://chatgpt.com/codex/tasks/task_e_6843be1aea9c832c8734247b3fe2ff74